### PR TITLE
Removing extra "exit" instruction

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -29,7 +29,6 @@ if [ $? -eq 1 ]; then
 echo ERROR: openssl is missing. Please install first
 exit 0
 fi
-exit
 
 if [ $# -ne 2 ]; then
 echo usage: ./init.sh \<domain\> \<ip\>


### PR DESCRIPTION
This extra "exit" instruction was probably left behind for debugging proposes. This should be removed otherwise the script wouldn't run.

Great work here!